### PR TITLE
Fixes to known bugs

### DIFF
--- a/lib/rxnorm.js
+++ b/lib/rxnorm.js
@@ -8,7 +8,8 @@ var fs          = require("fs"),
 
 // generic GET query with any endpoint
 function query(base, q, callback) {
-    var url = util.format("%s?%s", base, querystring.stringify(q));
+    // Added unescape to fix URI errors resulting from hexadecimal escape sequences
+    var url = util.format("%s?%s", base, querystring.unescape(querystring.stringify(q)));
     request(url, function (err, response) {
         if (err) return callback(err);
         callback(null, response.body);
@@ -176,9 +177,12 @@ function drugFormList(drugs, callback) {
                                     }
                                     cb4();
                                 } else {
-                                    if (drug.synonym.indexOf(doseFormGroups[i]) !== -1) {
-                                        possibleFormList.push(doseFormGroups[i]);
-                                        possibleDrugFormList.push(doseFormGroups[i]);
+                                    // There are cases when drug.synonym is not a string and we end up with errors
+                                    if (typeof drug.synonym === "string") {
+                                        if (drug.synonym.indexOf(doseFormGroups[i]) !== -1) {
+                                            possibleFormList.push(doseFormGroups[i]);
+                                            possibleDrugFormList.push(doseFormGroups[i]);
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
This PR: 
- Added unescape to fix URI errors resulting from hexadecimal escape sequences (see line 12)
- Add a check for the case when a result of a query does not have a synonym (see line 181)